### PR TITLE
通知に参加中のプレイヤー数を追加

### DIFF
--- a/src/main/kotlin/com/oykdn/mc/waterfalldiscordnotifier/channel/discord/DiscordChannel.kt
+++ b/src/main/kotlin/com/oykdn/mc/waterfalldiscordnotifier/channel/discord/DiscordChannel.kt
@@ -36,12 +36,24 @@ class DiscordChannel(
             return
         }
 
-        // Leftイベント以外は移動先のサーバ情報も付ける
-        val fields = listOfNotNull(n.to?.let {
-            DiscordWebhookEmbedField(
-                "サーバ", "`$it`", true
+        val fields = mutableListOf<DiscordWebhookEmbedField>()
+
+        // Left以外の場合、追加情報を通知に付与
+        n.to?.let {
+            // サーバ名
+            fields.add(
+                DiscordWebhookEmbedField(
+                    "サーバ", "`$it`", true
+                )
             )
-        })
+
+            // 参加プレイヤー数
+            fields.add(
+                DiscordWebhookEmbedField(
+                    "参加プレイヤー数", "`${n.playerCountInServer}`", true
+                )
+            )
+        }
 
         val embeds = listOf(
             DiscordWebhookEmbed(

--- a/src/main/kotlin/com/oykdn/mc/waterfalldiscordnotifier/listener/BungeePlayerEventListener.kt
+++ b/src/main/kotlin/com/oykdn/mc/waterfalldiscordnotifier/listener/BungeePlayerEventListener.kt
@@ -15,10 +15,12 @@ class BungeePlayerEventListener(
      */
     @EventHandler
     fun onServerSwitch(event: ServerSwitchEvent) {
+        val serverInfo = event.player.server.info
+
         notifier.send(Notification(event.player.name,
             event.player.uniqueId,
             event.from?.let { PlayerEventType.ServerSwitched } ?: PlayerEventType.ProxyJoined,
-            event.player.server.info.name))
+            serverInfo.name, serverInfo.players.size))
     }
 
     /**
@@ -28,7 +30,7 @@ class BungeePlayerEventListener(
     fun onPlayerDisconnect(event: PlayerDisconnectEvent) {
         notifier.send(
             Notification(
-                event.player.name, event.player.uniqueId, PlayerEventType.ProxyLeft, null
+                event.player.name, event.player.uniqueId, PlayerEventType.ProxyLeft, null, null
             )
         )
     }

--- a/src/main/kotlin/com/oykdn/mc/waterfalldiscordnotifier/model/Notification.kt
+++ b/src/main/kotlin/com/oykdn/mc/waterfalldiscordnotifier/model/Notification.kt
@@ -10,4 +10,5 @@ data class Notification(
     val uuid: UUID, // プレイヤーUUID
     val type: PlayerEventType, // イベント種別
     val to: String?, // 移動先サーバ名
+    val playerCountInServer: Int?, // サーバ内参加プレイヤー数
 )


### PR DESCRIPTION
参加中にプレイヤー数を通知するようにしました。
参加時及びサーバ切替時に通知されます。

![image](https://github.com/oyakodon/waterfall-discord-notifier/assets/16263307/8afd086a-bb9d-46b2-900f-6829b40a6f4e)
